### PR TITLE
Added excludeDirsAbsolute flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ robocopy({
         // [/xd <Directory>[ ...]]
         excludeDirs: ['tmp', 'obj'],
 
+	// Excludes directories that match the specified names in top level directory only
+        excludeDirsAbsolute: true|false,
+
         // Excludes changed files. [/xct]
         excludeChangedFiles: true|false,
 

--- a/src/command.js
+++ b/src/command.js
@@ -92,17 +92,17 @@ function buildCommand(options) {
 
         if (file.excludeDirs && file.excludeDirs.length > 0) {
             args.push('/xd');
-	    if(file.excludeDirsAbsolute) {
-		 var excludeDirs = 
+	    if(file.excludeDirsAbsolute && file.excludeDirsAbsolute == false) {
+		args = args.concat(qualify(toWindowsPath(file.excludeDirs)));
+	    } else {
+		var excludeDirs = 
                 _.chain(toAbsolutePath(file.excludeDirs, source)
                     .concat(toAbsolutePath(file.excludeDirs, destination)))
                     .uniq()
                     .map(toWindowsPath)
                     .map(qualify)
                     .value();
-                 args = args.concat(excludeDirs);
-	    } else {
-		args = args.concat(qualify(toWindowsPath(file.excludeDirs)));
+                args = args.concat(excludeDirs);
 	    }    
         }
 

--- a/src/command.js
+++ b/src/command.js
@@ -92,8 +92,8 @@ function buildCommand(options) {
 
         if (file.excludeDirs && file.excludeDirs.length > 0) {
             args.push('/xd');
-
-            var excludeDirs = 
+	    if(file.excludeDirsAbsolute) {
+		 var excludeDirs = 
                 _.chain(toAbsolutePath(file.excludeDirs, source)
                     .concat(toAbsolutePath(file.excludeDirs, destination)))
                     .uniq()
@@ -101,7 +101,14 @@ function buildCommand(options) {
                     .map(qualify)
                     .value();
 
-            args = args.concat(excludeDirs);
+                 args = args.concat(excludeDirs);
+	    } else {
+
+		args = args.concat(qualify(toWindowsPath(file.excludeDirs)));
+
+	    }
+		
+           
         }
 
         if (file.excludeChangedFiles) args.push('/xct');

--- a/src/command.js
+++ b/src/command.js
@@ -100,15 +100,10 @@ function buildCommand(options) {
                     .map(toWindowsPath)
                     .map(qualify)
                     .value();
-
                  args = args.concat(excludeDirs);
 	    } else {
-
 		args = args.concat(qualify(toWindowsPath(file.excludeDirs)));
-
-	    }
-		
-           
+	    }    
         }
 
         if (file.excludeChangedFiles) args.push('/xct');


### PR DESCRIPTION
Added `excludeDirsAbsolute` flag to make sure `/xd` option in robocopy just uses the folder name and the same folder is excluded even if it is present in some sub-directory.
