### PR TITLE
use the readline interface for piping stdout/stderr

### DIFF
--- a/src/process.js
+++ b/src/process.js
@@ -27,7 +27,7 @@ module.exports = function(command) {
         }).on('line', function(line) {
             output += log(line);
         });
-    }
+    };
 
     redirect(robocopy.stdout, stdout);
     redirect(robocopy.stderr, stderr);

--- a/src/process.js
+++ b/src/process.js
@@ -1,6 +1,7 @@
 var process = require('child_process'),
     Q = require('q'),
-    parser = require('./parser');
+    parser = require('./parser'),
+    readline = require('readline');
 
 module.exports = function(command) {
 
@@ -20,8 +21,16 @@ module.exports = function(command) {
     var stdout = '';
     var stderr = '';
 
-    robocopy.stdout.on('data', function(message) { stdout += log(message); });
-    robocopy.stderr.on('data', function(message) { stderr += log(message); });
+    var redirect = function (input, output) {
+        readline.createInterface({
+            input: input
+        }).on('line', function(line) {
+            output += log(line);
+        });
+    }
+
+    redirect(robocopy.stdout, stdout);
+    redirect(robocopy.stderr, stderr);
 
     var deferred = Q.defer();
 

--- a/src/process.js
+++ b/src/process.js
@@ -21,16 +21,14 @@ module.exports = function(command) {
     var stdout = '';
     var stderr = '';
 
-    var redirect = function (input, output) {
+    var readlines = function (input, listener) {
         readline.createInterface({
             input: input
-        }).on('line', function(line) {
-            output += log(line);
-        });
+        }).on('line', listener);
     };
 
-    redirect(robocopy.stdout, stdout);
-    redirect(robocopy.stderr, stderr);
+    readlines(robocopy.stdout, function(line) { stdout += log(line); });
+    readlines(robocopy.stderr, function(line) { stderr += log(line); });
 
     var deferred = Q.defer();
 


### PR DESCRIPTION
This removes all the extra line breaks that get sent to the console.