### PR TITLE
Use Array.isArray() instead of instanceof Array to handle arrays.

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -15,7 +15,7 @@ function toWindowsPath(path) {
         if (p.substr(-1) === '\\') p = p.substr(0, p.length - 1);
         return p;
     };
-    if (path instanceof Array) return path.map(clean);
+    if (Array.isArray(path)) return path.map(clean);
     else return clean(path);
 }
 
@@ -24,7 +24,7 @@ function toAbsolutePath(relativePath, base) {
         return _.startsWith(p, '\\\\') || _.include(p, ':') ? p : 
             (base ? path.join(base, p) : path.resolve(p));
     };
-    if (relativePath instanceof Array) return relativePath.map(toAbsolute);
+    if (Array.isArray(relativePath)) return relativePath.map(toAbsolute);
     else return toAbsolute(relativePath);
 }
 


### PR DESCRIPTION
To detect correctly arrays,  `Array.isArray()` should be preferred to `instanceof Array`. This improvement would allow node-robocopy to work correctly in more complex situations, such as when embedded in a Electron or NW.JS application. 

This is explained by inaccurate results of `instanceof Array` when it is used across different context:

>  However, since instanceof Array doesn't work correctly across iframes/window, Array.isArray() would be more robust solution.

Source: [https://stackoverflow.com/a/22289982](https://stackoverflow.com/a/22289982)